### PR TITLE
Add text to canvas functionality

### DIFF
--- a/VisioChat_Agents.json
+++ b/VisioChat_Agents.json
@@ -249,6 +249,21 @@
         -40,
         1040
       ]
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "### System:\nYou are an Action Agent that interprets user requests and generates commands for shapes and text in a Visio-like system.\n\n### Instructions:\n- Your job is to return a clean, valid JSON structure without additional explanation or text.\n- If the user's request is to create a shape or add text, return the appropriate JSON command.\n- The JSON should contain only the required data without any additional information or explanation.\n\n### User Message:\n{{ $json.chatInput || $json.body.message }}\n\n### Respond with:\n{\n  \"command\": \"<command_name>\",\n  \"parameters\": {\n    \"shapeType\": \"<shape_type>\",\n    \"position\": { \"x\": <percent_x>, \"y\": <percent_y> },\n    \"size\": { \"width\": <percent_width>, \"height\": <percent_height> },\n    \"color\": \"<color>\"\n  }\n}\nOR\n{\n  \"command\": \"CreateText\",\n  \"parameters\": {\n    \"textContent\": \"<text_content>\",\n    \"position\": { \"x\": <percent_x>, \"y\": <percent_y> },\n    \"fontSize\": <font_size>,\n    \"color\": \"<color>\"\n  }\n}",
+        "options": {}
+      },
+      "id": "ff5a872f-3380-4fcc-9d87-25d50e382b31",
+      "name": "action_agent1",
+      "type": "@n8n/n8n-nodes-langchain.agent",
+      "typeVersion": 1.6,
+      "position": [
+        -40,
+        1040
+      ]
     }
   ],
   "pinData": {},


### PR DESCRIPTION
Add functionality to support text addition to the Visio canvas via API and Visio-command.

* **VisioCommandProcessor.cs**
  - Add `CreateText` command to handle text addition to the canvas.
  - Implement `CreateText` command to accept parameters for text content, position, font size, and color.
  - Process the `CreateText` command to add text to the Visio page with specified attributes.

* **VisioChat_Agents.json**
  - Add commands for text addition to the JSON structure.
  - Include parameters for text content, position, font size, and color in the JSON command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Therealkorris/VisioCreator/tree/enhance-visio-plugin?shareId=ccd1f973-8f60-4681-acdb-966b8c657201).